### PR TITLE
Added simple content wrapper to avoid wide lines of text on wide screens

### DIFF
--- a/blinkwink/static/css/main.css
+++ b/blinkwink/static/css/main.css
@@ -3,6 +3,16 @@ body {
   background: #eee;
 }
 
+.wrapper {
+    margin-left: auto;
+    margin-right: auto;
+    
+    max-width: 960px;
+
+    padding-right: 10px;
+    padding-left: 10px;
+}
+
 a, h1, h2 {
   color: #377BA8;
 }

--- a/blinkwink/templates/_base.html
+++ b/blinkwink/templates/_base.html
@@ -4,9 +4,12 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
 <body>
-  {% block content %}
-  {% endblock %}
-  {% block footer %}
-  <div><a href={{ url_for('main.index') }}>Home</a></div>
-  {% endblock %}
+  <div class="wrapper">
+    {% block content %}
+    {% endblock %}
+
+    {% block footer %}
+    <div><a href={{ url_for('main.index') }}>Home</a></div>
+    {% endblock %}
+  </div>
 </body>


### PR DESCRIPTION
Bounds all content to a maximum of 960px, with 10px at the left and right margins for padding, to account for screens that are exactly 980px wide.  The intention is to reduce the maximum width of lines of text, improving readability by reducing the amount of side-to-side scanning necessary on wide screens.