### PR TITLE
Reorient links so that off-site links trail on-site links

### DIFF
--- a/blinkwink/templates/index.html
+++ b/blinkwink/templates/index.html
@@ -3,6 +3,16 @@
     <h1>Salutations</h1>
     <p>Welcome to Ima's place.  I don't have a whole lot going on here.  Maybe soon.  For now, enjoy a neat thing or two that I have come across in my travels.</p>
 
+    <h2>Onsite Links</h2>
+    <h3>ePortfolio</h3>
+    <ul>
+        <li><a href={{ url_for('main.econ') }}>Economic History of the United States Presentation</a></li>
+        <li><a href={{ url_for('main.reasoning') }}>Reasoning and Rational Decision Making Project</a></li>
+        <li><a href={{ url_for('main.english') }}>Introduction to Writing - Research Paper</a></li>
+        <li><a href={{ url_for('main.english_2') }}>Intermediate Writing - Report Paper</a></li>
+        <li><a href={{ url_for('main.stats') }}>Statistics for Applied Science - Research Project</a></li>
+    </ul>
+
     <h2>Offsite Links</h2>
     <h3>Productivity</h3>
     <ul>
@@ -21,15 +31,6 @@
          <li><a href="http://hpmor.com/">Harry Potter and the Methods of Rationality</a></li>
          <li><a href="http://luminous.elcenia.com/">Luminosity: Twilight Reimagined</a></li>
          <li><a href="https://glowfic.com/">Glowfic</a></li>
-    </ul>
-
-    <h2>Onsite Links</h2>
-    <ul>
-        <li><a href={{ url_for('main.econ') }}>Economic History of the United States Presentation</a></li>
-        <li><a href={{ url_for('main.reasoning') }}>Reasoning and Rational Decision Making Project</a></li>
-        <li><a href={{ url_for('main.english') }}>Introduction to Writing - Research Paper</a></li>
-        <li><a href={{ url_for('main.english_2') }}>Intermediate Writing - Report Paper</a></li>
-        <li><a href={{ url_for('main.stats') }}>Statistics for Applied Science - Research Project</a></li>
     </ul>
 {% endblock %}
 


### PR DESCRIPTION
Prior to this change, the landing page consisted of a list of links off of the page, followed by a smaller list of on-site links.  The on-site links had no explanation beyond being on-site links.  This change places the on-site links higher on the page, followed by the off-site links.  It also adds a subsection heading for the on-site links to make it clear that they specifically refer to my ePortfolio.