### PR TITLE
Ignore Emacs file backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ ENV/
 
 # Emacs temp files
 .\#*
+*.*~


### PR DESCRIPTION
Emacs occasionally creates backups of files which end with a tilde (~).  By default, these files are created in the same directory as the original files, which can be picked up by git.  This change causes such files to be ignored.