### PR TITLE
Added specific instructions about creating an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,16 @@ To build this project locally, the following steps must be performed (I think; l
 - Clone the repository
 - Create a local Python virtual environment
 - Activate the new virtual environment
-- Install the various dependencies found in Requirements.txt
+- Install the various dependencies found in `Requirements.txt`
 - Create a file called `settings.cfg` in `/blinkwink/blinkwink` at the same level as `config.py`
    - This file should contain the following two lines:
    - `WTF_CSRF_ENABLED = True`
    - `SECRET_KEY = "Your super-secret key that you should never share with anyone"`
+- Set up an environment variable to point at this file:
+
+```bash
+export BLINKWINK_CONFIG=settings.cfg
+```
 
 # To Run This Project Locally
 


### PR DESCRIPTION
By default, the project looks to a "BLINKWINK_CONFIG" environment variable in order to find some configuration information necessary to start the server.  This adds some minimal detail to the readme for configuring that variable.